### PR TITLE
(Sprint 1) Construcción de servicio eco HTTP e implementación de Makefile mínimo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Variables de entorno 
+PORT ?= 8080
+HOST ?= localhost
+RELEASE ?= v0.1.0
+
+# Directorios
+SRC_DIR := src
+DOCS_DIR := docs
+OUT_DIR := out
+DIST_DIR := dist
+TEST_DIR := tests
+
+# Archivo de empaquetado
+DIST_FILE := $(DIST_DIR)/proyecto-$(RELEASE).tar.gz
+
+# Lista de herramientas
+TOOLS = nc curl dig openssl bats
+
+.PHONY: tools build run test pack clean help
+
+help:
+	@echo "Uso: make <target>"
+	@echo ""
+	@echo "Targets disponibles:"
+	@echo "  tools   - Verificar herramientas necesarias ($(TOOLS))"
+	@echo "  build   - Generar artefactos intermedios en $(OUT_DIR)/"
+	@echo "  run     - Iniciar el servicio eco"
+	@echo "  test    - Ejecutar prueba básica con curl"
+	@echo "  pack    - Empaquetar release en $(DIST_DIR)"
+	@echo "  clean   - Limpiar artefactos"
+
+tools:
+	@echo "Verificando que herramientas necesarias estén instaladas..."
+	@for tool in $(TOOLS); do \
+		if ! command -v $$tool >/dev/null 2>&1; then \
+			echo "Falta instalar $$tool"; \
+			exit 1; \
+		else \
+			echo "$$tool disponible"; \
+		fi; \
+	done
+
+build:
+test:
+run:
+	@PORT=$(PORT) HOST=$(HOST) bash $(SRC_DIR)/servicio_http_eco.sh
+
+$(DIST_FILE): $(SRC_DIR)/* $(DOCS_DIR)/* Makefile
+	@echo "Empaquetando proyecto en $@..."
+	@mkdir -p $(DIST_DIR)
+	@tar -czf $@ $(SRC_DIR) $(DOCS_DIR) Makefile
+
+pack: $(DIST_FILE)
+	@echo "Empaquetado listo: $(DIST_FILE)"
+
+clean:
+	@echo "Limpiando $(OUT_DIR)/ y $(DIST_DIR)/..."
+	@rm -rf $(OUT_DIR) $(DIST_DIR)

--- a/src/servicio_http_eco.sh
+++ b/src/servicio_http_eco.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Variables de entorno con defaults
+PORT="${PORT:-8080}"
+HOST="${HOST:-127.0.0.1}"
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+pipe=""
+
+# Se elimina el archivo de pipe
+cleanup() {
+  if [ -n "${pipe:-}" ] && [ -e "$pipe" ]; then
+    rm -f "$pipe"
+  fi
+}
+
+trap cleanup EXIT SIGINT SIGTERM
+
+echo "Servidor escuchando en http://${HOST}:${PORT} ..." >&2
+
+while true; do
+  # Se obtiene un nombre temporal en tmp/ y se usa para definir el pipe con mkfifo
+  pipe=$(mktemp -u /tmp/server_pipe.XXXXXX)
+  mkfifo "$pipe" || { echo "No se pudo crear FIFO" >&2; exit 1; }
+
+  # Servidor usando netcat
+  nc -l -p "$PORT" <"$pipe" | (
+    read -r request_line || exit 1
+
+    # Ignora los headers hasta la línea en blanco
+    while read -r line; do
+      line="${line%%$'\r'}"
+      [ -z "$line" ] && break
+    done
+
+    method="$(echo "$request_line" | awk '{print $1}')"
+    path="$(echo "$request_line" | awk '{print $2}')"
+    version="$(echo "$request_line" | awk '{print $3}')"
+
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    
+    echo "[$timestamp] $request_line" >&2
+
+    # Validación de petición (métodos soportados, mala petición, rutas permitidas)
+    case "$method" in
+      "GET"|"HEAD")
+        case "$path" in
+          "/salud")
+            status="200 OK"
+            body="Servicio operativo"
+            ;;
+          *) 
+            status="404 Not Found"
+            body="Error 404: Resource not found"
+            ;;
+        esac
+        ;;
+      "")
+        status="400 Bad Request"
+        body="Error 400: Bad Request - Missing HTTP method"
+        ;;
+      *)
+        status="405 Method Not Allowed"
+        body="Error 405: Method Not Allowed - Supported: GET, HEAD"
+        ;;
+    esac
+
+    # Cabeceras HTTP
+    response_headers=""
+    response_headers+="HTTP/1.1 $status"$'\r\n'
+    response_headers+="Content-Type: text/plain"$'\r\n'
+    response_headers+="Server: BashHTTP/1.0"$'\r\n'
+    response_headers+="Date: $(date -u '+%a, %d %b %Y %H:%M:%S GMT')"$'\r\n'
+    response_headers+="Connection: close"$'\r\n'
+
+    # Enviar respuesta
+    echo -e "$response_headers"
+    echo -e "$body"
+
+    echo "[$timestamp] Response: $status (Method: $method, Path: $path)" >&2
+  ) >"$pipe"
+
+  # Se elimina el nombre aleatorio del pipe, para usar otro para la siguiente petición
+  rm -f "$pipe"
+  pipe=""
+done


### PR DESCRIPTION
## Cambios principales
- Se agregó `src/servicio_http_eco.sh`:
  - Simula un servidor HTTP recibiendo infinitamente peticiones con `nc`
  - Hace uso de `named pipes` para poder devolver una respuesta a la terminal del cliente
  - Por ahora, solo soporta los métodos `HEAD/GET` y la ruta `salud/`.

## Evidencias
Con `curl` podemos hacer peticiones desde otra terminal y, se obtendrán respuestas, así como en la terminal del servidor se verán las peticiones realizadas al servidor junto a la fecha.