### PR TITLE
Feature/jhon dns systemd

### DIFF
--- a/src/dns-utils.sh
+++ b/src/dns-utils.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Variables de entorno
+DNS_SERVER="${DNS_SERVER:-}" # vacio para usar localmente
+DOMINIO="${DOMINIO:-localhost}"
+
+# Resolución de registro A
+resolver_a() {
+    local dominio="$1"
+    echo "Resolviendo A para: $dominio" >&2
+    local result
+    if [[ -z "$DNS_SERVER" ]]; then # su DNS_SERVER esta vacio usa resolucion por defecto
+        result=$(dig +short +nocmd -t A "$dominio" 2>/dev/null | head -1 || true) # toma solo la ip
+    else
+        result=$(dig +short +nocmd -t A "$dominio" @"$DNS_SERVER" 2>/dev/null | head -1 || true)
+    fi
+    echo "$result" # muestra el resultado
+}
+
+# Resolucion de registro CNAME (lo mismo pero con los alias)
+resolver_cname() {
+    local dominio="$1"
+    echo "Resolviendo CNAME para: $dominio" >&2
+    local result
+    if [[ -z "$DNS_SERVER" ]]; then
+        result=$(dig +short +nocmd -t CNAME "$dominio" 2>/dev/null | head -1 || true)
+    else
+        result=$(dig +short +nocmd -t CNAME "$dominio" @"$DNS_SERVER" 2>/dev/null | head -1 || true)
+    fi
+    echo "$result"
+}
+
+# Parseo de TTL
+obtener_ttl() {
+    local dominio="$1"
+    local tipo_registro="${2:-A}"
+    local ttl_line ttl # ttl guarda respuesta completa dig, ttl solo el segndo argumento
+
+    if [[ -z "$DNS_SERVER" ]]; then # -z -> string long 0 (es decir vacio)
+        ttl_line=$(dig +noall +answer -t "$tipo_registro" "$dominio" 2>/dev/null || true) # noall muestra la respuesta ttl
+    else
+        ttl_line=$(dig +noall +answer -t "$tipo_registro" "$dominio" @"$DNS_SERVER" 2>/dev/null || true)
+    fi
+
+    # Buscar la primera linea de respuesta que tenga el host (con o sin punto final)
+    ttl=$(printf "%s\n" "$ttl_line" | awk -v d="$dominio" '{  # verifica que dominio coincida con $1
+        host=$1
+        sub(/\.$/,"",host)            # quitar posible punto final
+        if (host==d) {
+            for(i=2;i<=NF;i++){ # si existe coincidencia extrae el segundo valor
+                if ($i ~ /^[0-9]+$/) { print $i; exit }
+            }
+        }
+    }' | head -n1 || true)
+
+    if [[ -z "$ttl" ]]; then
+        echo "0"
+    else
+        echo "$ttl"
+    fi
+}
+
+# Función principal - Solo análisis DNS
+analizar_dns() {
+    local dominio="$1"
+    
+    echo "=== Analisis DNS para: $dominio ==="
+    echo "Registro A: $(resolver_a "$dominio")"
+    echo "Registro CNAME: $(resolver_cname "$dominio")"
+    echo "TTL (A): $(obtener_ttl "$dominio" A) segundos"
+    echo "=== Fin análisis ==="
+}
+
+# Ejecucutar
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    analizar_dns "${DOMINIO}"
+fi

--- a/src/dns-utils.sh
+++ b/src/dns-utils.sh
@@ -10,7 +10,7 @@ resolver_a() {
     local dominio="$1"
     echo "Resolviendo A para: $dominio" >&2
     local result
-    if [[ -z "$DNS_SERVER" ]]; then # su DNS_SERVER esta vacio usa resolucion por defecto
+    if [[ -z "$DNS_SERVER" ]]; then                                               # su DNS_SERVER esta vacio usa resolucion por defecto
         result=$(dig +short +nocmd -t A "$dominio" 2>/dev/null | head -1 || true) # toma solo la ip
     else
         result=$(dig +short +nocmd -t A "$dominio" @"$DNS_SERVER" 2>/dev/null | head -1 || true)
@@ -37,7 +37,7 @@ obtener_ttl() {
     local tipo_registro="${2:-A}"
     local ttl_line ttl # ttl guarda respuesta completa dig, ttl solo el segndo argumento
 
-    if [[ -z "$DNS_SERVER" ]]; then # -z -> string long 0 (es decir vacio)
+    if [[ -z "$DNS_SERVER" ]]; then                                                       # -z -> string long 0 (es decir vacio)
         ttl_line=$(dig +noall +answer -t "$tipo_registro" "$dominio" 2>/dev/null || true) # noall muestra la respuesta ttl
     else
         ttl_line=$(dig +noall +answer -t "$tipo_registro" "$dominio" @"$DNS_SERVER" 2>/dev/null || true)
@@ -64,7 +64,7 @@ obtener_ttl() {
 # Función principal - Solo análisis DNS
 analizar_dns() {
     local dominio="$1"
-    
+
     echo "=== Analisis DNS para: $dominio ==="
     echo "Registro A: $(resolver_a "$dominio")"
     echo "Registro CNAME: $(resolver_cname "$dominio")"

--- a/systemd/servicio-eco.service
+++ b/systemd/servicio-eco.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Servicio Eco DNS Analysis
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/tmp
+Environment="DNS_SERVER=8.8.8.8" "DOMINIO=localhost"
+ExecStart=/bin/bash /path/to/src/dns-utils.sh
+Restart=no
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/dns-resolucion.bats
+++ b/tests/dns-resolucion.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    source src/dns-utils.sh
+}
+
+@test "Resolucion A funciona" {
+    run resolver_a "localhost"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"127.0.0.1"* ]]
+}
+
+@test "Resolucion CNAME funciona" {
+    run resolver_cname "localhost"
+    [ "$status" -eq 0 ]
+    # Puede estar vacío, no debe fallar
+}
+
+@test "Parseo TTL funciona" {
+    run obtener_ttl "localhost" "A"
+    [ "$status" -eq 0 ]
+    # Solo verifica que es un número (0 es válido)
+    [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+@test "Analisis DNS completo funciona" {
+    run analizar_dns "localhost"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Análisis DNS"* ]]
+}

--- a/tests/dns-resolucion.bats
+++ b/tests/dns-resolucion.bats
@@ -26,5 +26,5 @@ setup() {
 @test "Analisis DNS completo funciona" {
     run analizar_dns "localhost"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Análisis DNS"* ]]
+    [[ "$output" == *"Analisis DNS"* ]]
 }


### PR DESCRIPTION
### Rama: `feature/dns-systemd`

**Cambios principales**  
Se agrego `src/dns-utils.sh` con funciones para resolver registros DNS  
- `resolver_a`: obtiene la direccion IP asociada (registro A)  
- `resolver_cname`: obtiene el alias asociado (CNAME)  
- `resolver_ttl`: parsea y muestra el TTL del dominio  

Tambien se configuro una unidad basica de **systemd** (`systemd/servicio-eco.service`) para levantar el servicio, se anadieron pruebas iniciales con **Bats** (`tests/dns-resolucion.bats`) y se habilito el logging con **journalctl**  
Ademas se creo la documentacion inicial (`contrato-salidas.md`, `bitacora-sprint-1.md`)  

**Evidencias**  
- Con `bats tests/dns-resolucion.bats` se validan las resoluciones A y CNAME  
- Usando `dig` se pueden obtener los registros junto al TTL  
- Con `journalctl -u servicio-eco.service` se registran y consultan los logs del servicio  
