### PR TITLE
(Sprint 2) Implementación de nuevo endpoint en servicio eco HTTP y captura de trazas de HTTP/HTTPS(TLS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ PORT ?= 8080
 HOST ?= localhost
 RELEASE ?= v0.1.0
 DNS_SERVER ?= 
+DOMINIO ?= localhost
+TARGET_HOST ?= example.org
+TARGET_PORT ?= 443
 
 # Directorios
 SRC_DIR := src
@@ -17,18 +20,24 @@ DIST_FILE := $(DIST_DIR)/proyecto-$(RELEASE).tar.gz
 # Lista de herramientas
 TOOLS = nc curl dig openssl bats
 
-.PHONY: tools build run test pack clean help
+.PHONY: tools build run test pack clean help tools-dns test-dns run-dns systemd-setup systemd-test test-http
 
 help:
 	@echo "Uso: make <target>"
 	@echo ""
-	@echo "Targets disponibles:"
-	@echo "  tools   - Verificar herramientas necesarias ($(TOOLS))"
-	@echo "  build   - Generar artefactos intermedios en $(OUT_DIR)/"
-	@echo "  run     - Iniciar el servicio eco"
-	@echo "  test    - Ejecutar prueba básica con curl"
-	@echo "  pack    - Empaquetar release en $(DIST_DIR)"
-	@echo "  clean   - Limpiar artefactos"
+	@echo "Targets generales:"
+	@echo " tools   - Verificar herramientas necesarias ($(TOOLS))"
+	@echo " build   - Generar artefactos en $(OUT_DIR)/"
+	@echo " run     - Iniciar el servicio eco HTTP"
+	@echo " test    - Ejecutar pruebas bats de systemd, DNS y del servicio HTTP"
+	@echo " pack    - Empaquetar release en $(DIST_DIR)"
+	@echo " clean   - Limpiar artefactos"
+	@echo "Targets específicos:"
+	@echo " run-dns 	  - Ejecución de análisis de DNS"
+	@echo " systemd-setup 	  - Configuración de unidad systemd"
+	@echo " test-dns 	  - Pruebas bats para DNS"
+	@echo " systemd-test  	  - Pruebas bats para la unidad systemd"
+	@echo " test-http 	  - Pruebas bats para el servicio HTTP"
 
 tools:
 	@echo "Verificando que herramientas necesarias estén instaladas..."
@@ -42,7 +51,16 @@ tools:
 	done
 
 build:
+	@mkdir -p $(OUT_DIR)
+	@echo "Ejecutando analizador de conexión (HTTP/HTTPS)..."
+	@LOCAL_PORT=$(PORT) LOCAL_HOST=$(HOST) TARGET_PORT=$(TARGET_PORT) TARGET_HOST=$(TARGET_HOST) bash $(SRC_DIR)/handshake_analizer.sh
+
 test:
+	@echo "Ejecutando todas las pruebas bats (DNS, systemd, http)..."
+	$(MAKE) test-dns
+	$(MAKE) test-http
+	$(MAKE) systemd-test
+
 run:
 	@PORT=$(PORT) HOST=$(HOST) bash $(SRC_DIR)/servicio_http_eco.sh
 
@@ -51,28 +69,13 @@ $(DIST_FILE): $(SRC_DIR)/* $(DOCS_DIR)/* Makefile
 	@mkdir -p $(DIST_DIR)
 	@tar -czf $@ $(SRC_DIR) $(DOCS_DIR) Makefile
 
+# Empaquetar el proyecto
 pack: $(DIST_FILE)
 	@echo "Empaquetado listo: $(DIST_FILE)"
 
 clean:
 	@echo "Limpiando $(OUT_DIR)/ y $(DIST_DIR)/..."
 	@rm -rf $(OUT_DIR) $(DIST_DIR)
-
-
-
-.PHONY: tools-dns test-dns run-dns systemd-setup systemd-test
-
-# Variables DNS
-DNS_SERVER ?= 
-DOMINIO ?= localhost
-
-# Verificar herramientas DNS
-tools-dns:
-	@echo "Verificando herramientas DNS..."
-	@for tool in dig; do \
-		command -v $$tool >/dev/null 2>&1 || { echo "Falta $$tool"; exit 1; } \
-	done
-	@echo "Todas las herramientas DNS disponibles"
 
 # Ejecutar análisis DNS
 run-dns:
@@ -103,3 +106,8 @@ systemd-test:
 	@systemctl --user status servicio-eco || true
 	@systemctl --user stop servicio-eco
 	@echo "Prueba de unidad systemd completada"
+
+# Probar servicio eco HTTP
+test-http:
+	@echo "Probando servicio eco HTTP..."
+	@PORT=$(PORT) HOST=$(HOST) bats $(TEST_DIR)/test-http-service.bats

--- a/src/handshake_analizer.sh
+++ b/src/handshake_analizer.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/out"
+mkdir -p "$OUT_DIR"
+
+# Config variables
+LOCAL_HOST="${HOST:-localhost}"
+LOCAL_PORT="${PORT:-8080}"
+TARGET_HOST="${TARGET_HOST:-example.org}"
+TARGET_PORT="${TARGET_PORT:-443}"
+
+echo -n "" > $OUT_DIR/ss_trace.txt
+
+(
+    i=0
+    while true; do
+        i=$((i + 1))
+        echo ">>> Salida $i" >> "$OUT_DIR/ss_trace.txt"
+        ss -tanp | grep -E "(nc|openssl|curl)" >> "$OUT_DIR/ss_trace.txt"
+        sleep 0.1
+    done
+) &
+SS_PID=$!
+
+echo "Capturando traza HTTP local (servicio local - GET /salud)..." >&2
+curl -v "http://${LOCAL_HOST}:${LOCAL_PORT}/salud" -s -o /dev/null 2> "$OUT_DIR/http_local_post_traza.txt" || true
+
+echo "Capturando traza HTTPS (servicio público ${TARGET_HOST} - GET)..." >&2
+curl -v "https://${TARGET_HOST}" -s -o /dev/null 2> "$OUT_DIR/https_${TARGET_HOST}_traza.txt" || true
+
+echo "Ejecutando openssl s_client para inspeccionar certificado..." >&2
+# redirige stdin para que s_client no espere
+openssl s_client -connect "${TARGET_HOST}:${TARGET_PORT}" -msg -showcerts < /dev/null > "$OUT_DIR/openssl_${TARGET_HOST}.txt" 2>&1 || true
+
+kill $SS_PID
+
+echo "Archivos generados en $OUT_DIR:" >&2
+ls -1 "$OUT_DIR"

--- a/src/servicio_http_eco.sh
+++ b/src/servicio_http_eco.sh
@@ -10,9 +10,9 @@ pipe=""
 
 # Se elimina el archivo de pipe
 cleanup() {
-  if [ -n "${pipe:-}" ] && [ -e "$pipe" ]; then
-    rm -f "$pipe"
-  fi
+    if [ -n "${pipe:-}" ] && [ -e "$pipe" ]; then
+        rm -f "$pipe"
+    fi
 }
 
 trap cleanup EXIT SIGINT SIGTERM
@@ -20,68 +20,71 @@ trap cleanup EXIT SIGINT SIGTERM
 echo "Servidor escuchando en http://${HOST}:${PORT} ..." >&2
 
 while true; do
-  # Se obtiene un nombre temporal en tmp/ y se usa para definir el pipe con mkfifo
-  pipe=$(mktemp -u /tmp/server_pipe.XXXXXX)
-  mkfifo "$pipe" || { echo "No se pudo crear FIFO" >&2; exit 1; }
+    # Se obtiene un nombre temporal en tmp/ y se usa para definir el pipe con mkfifo
+    pipe=$(mktemp -u /tmp/server_pipe.XXXXXX)
+    mkfifo "$pipe" || {
+        echo "No se pudo crear FIFO" >&2
+        exit 1
+    }
 
-  # Servidor usando netcat
-  nc -l -p "$PORT" <"$pipe" | (
-    read -r request_line || exit 1
+    # Servidor usando netcat
+    nc -l -p "$PORT" <"$pipe" | (
+        read -r request_line || exit 1
 
-    # Ignora los headers hasta la línea en blanco
-    while read -r line; do
-      line="${line%%$'\r'}"
-      [ -z "$line" ] && break
-    done
+        # Ignora los headers hasta la línea en blanco
+        while read -r line; do
+            line="${line%%$'\r'}"
+            [ -z "$line" ] && break
+        done
 
-    method="$(echo "$request_line" | awk '{print $1}')"
-    path="$(echo "$request_line" | awk '{print $2}')"
-    version="$(echo "$request_line" | awk '{print $3}' | tr -d '\r')"
+        method="$(echo "$request_line" | awk '{print $1}')"
+        path="$(echo "$request_line" | awk '{print $2}')"
+        version="$(echo "$request_line" | awk '{print $3}' | tr -d '\r')"
 
-    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    
-    echo "[$timestamp] $request_line" >&2
+        timestamp=$(date '+%Y-%m-%d %H:%M:%S')
 
-    # Validación de petición (métodos soportados, mala petición, rutas permitidas)
-    case "$method" in
-      "GET"|"HEAD")
-        case "$path" in
-          "/salud")
-            status="200 OK"
-            body="Servicio operativo"
+        echo "[$timestamp] $request_line" >&2
+
+        # Validación de petición (métodos soportados, mala petición, rutas permitidas)
+        case "$method" in
+        "GET" | "HEAD")
+            case "$path" in
+            "/salud")
+                status="200 OK"
+                body="Servicio operativo"
+                ;;
+            *)
+                status="404 Not Found"
+                body="Error 404: Resource not found"
+                ;;
+            esac
             ;;
-          *) 
-            status="404 Not Found"
-            body="Error 404: Resource not found"
+        "")
+            status="400 Bad Request"
+            body="Error 400: Bad Request - Missing HTTP method"
+            ;;
+        *)
+            status="405 Method Not Allowed"
+            body="Error 405: Method Not Allowed - Supported: GET, HEAD"
             ;;
         esac
-        ;;
-      "")
-        status="400 Bad Request"
-        body="Error 400: Bad Request - Missing HTTP method"
-        ;;
-      *)
-        status="405 Method Not Allowed"
-        body="Error 405: Method Not Allowed - Supported: GET, HEAD"
-        ;;
-    esac
 
-    # Cabeceras HTTP
-    response_headers=""
-    response_headers+="$version $status"$'\r\n'
-    response_headers+="Content-Type: text/plain"$'\r\n'
-    response_headers+="Server: BashHTTP/1.0"$'\r\n'
-    response_headers+="Date: $(date -u '+%a, %d %b %Y %H:%M:%S GMT')"$'\r\n'
-    response_headers+="Connection: close"$'\r\n'
+        # Cabeceras HTTP
+        response_headers=""
+        response_headers+="$version $status"$'\r\n'
+        response_headers+="Content-Type: text/plain"$'\r\n'
+        response_headers+="Server: BashHTTP/1.0"$'\r\n'
+        response_headers+="Date: $(date -u '+%a, %d %b %Y %H:%M:%S GMT')"$'\r\n'
+        response_headers+="Connection: close"$'\r\n'
 
-    # Enviar respuesta
-    echo -e "$response_headers"
-    echo -e "$body"
+        # Enviar respuesta
+        echo -e "$response_headers"
+        echo -e "$body"
 
-    echo "[$timestamp] Response: $status (Method: $method, Path: $path)" >&2
-  ) >"$pipe"
+        echo "[$timestamp] Response: $status (Method: $method, Path: $path)" >&2
+    ) >"$pipe"
 
-  # Se elimina el nombre aleatorio del pipe, para usar otro para la siguiente petición
-  rm -f "$pipe"
-  pipe=""
+    # Se elimina el nombre aleatorio del pipe, para usar otro para la siguiente petición
+    rm -f "$pipe"
+    pipe=""
 done

--- a/src/servicio_http_eco.sh
+++ b/src/servicio_http_eco.sh
@@ -36,7 +36,7 @@ while true; do
 
     method="$(echo "$request_line" | awk '{print $1}')"
     path="$(echo "$request_line" | awk '{print $2}')"
-    version="$(echo "$request_line" | awk '{print $3}')"
+    version="$(echo "$request_line" | awk '{print $3}' | tr -d '\r')"
 
     timestamp=$(date '+%Y-%m-%d %H:%M:%S')
     
@@ -68,7 +68,7 @@ while true; do
 
     # Cabeceras HTTP
     response_headers=""
-    response_headers+="HTTP/1.1 $status"$'\r\n'
+    response_headers+="$version $status"$'\r\n'
     response_headers+="Content-Type: text/plain"$'\r\n'
     response_headers+="Server: BashHTTP/1.0"$'\r\n'
     response_headers+="Date: $(date -u '+%a, %d %b %Y %H:%M:%S GMT')"$'\r\n'

--- a/tests/test-http-service.bats
+++ b/tests/test-http-service.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PORT="${PORT:-8080}"
+  export HOST="${HOST:-localhost}"
+}
+
+@test "POST /eco devuelve el mismo body (positivo)" {
+  run curl -s -X POST "http://${HOST}:${PORT}/eco" -d "hola"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hola" ]
+}
+
+@test "GET /salud devuelve 200 (positivo)" {
+  code=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}:${PORT}/salud")
+  [ "$code" -eq 200 ]
+}
+
+@test "GET recurso inexistente devuelve 404 (negativo)" {
+  code=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}:${PORT}/no-existe")
+  [ "$code" -eq 404 ]
+}
+
+@test "Host inválido falla (negativo)" {
+  run curl --max-time 2 -s "http://noexiste.local:${PORT}/eco"
+  [ "$status" -ne 0 ]
+}
+
+@test "Conexión a puerto inválido (negativo)" {
+  run curl --max-time 2 -s "http://${HOST}:9999/eco"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Cambios principales
- Se agregó `src/handshake_analizer.sh`:
  - Hace peticiones con `curl` tanto al servicio HTTP implementado en el sprint 1, como a un servidor público (`example.org`, por defecto) con HTTPS.
  - Inspecciona profundamente la conexión TLS con `openssl` (debido a HTTPS)
  - Se verifican que sockets, relacionados a los comandos, se abren al momento de su ejecución.

## Evidencias
### Archivos generados:
- `http_local_post_traza.txt`: Muestra detalles al realizar una petición `GET` al servicio eco HTTP.
- `https_example.org_traza.txt`: Muestra detalles al realizar una petición `GET` a un servicio público (TCP + TLS).
- `openssl_example.org.txt`: Muestra detalles de la conexión TLS (handshake, certificados, etc).
- `ss_trace.txt`: Muestra los sockets que han sido abiertos por los comandos ejecutados.